### PR TITLE
add gh pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Publish README to GitHub Pages
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install markdown
+        run: pip install markdown
+      - name: Convert README to HTML
+        run: |
+          python -c "
+          import markdown
+          with open('README.md', 'r') as f:
+              content = f.read()
+          html = markdown.markdown(content)
+          with open('index.html', 'w') as f:
+              f.write(html)
+          "
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: .
+          target-folder: .
+          clean: true
+          token: ${{ secrets.GH_PAGES_DEPLOY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,17 +14,9 @@ jobs:
         with:
           python-version: "3.x"
       - name: Install markdown
-        run: pip install markdown
+        run: pip install markdown pygments
       - name: Convert README to HTML
-        run: |
-          python -c "
-          import markdown
-          with open('README.md', 'r') as f:
-              content = f.read()
-          html = markdown.markdown(content)
-          with open('index.html', 'w') as f:
-              f.write(html)
-          "
+        run: python .github/workflows/readme_to_html.py
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/readme_to_html.py
+++ b/.github/workflows/readme_to_html.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import markdown
+from pygments.formatters import HtmlFormatter
+
+# Read README.md
+with open('README.md', 'r', encoding='utf-8') as f:
+    readme_content = f.read()
+
+# Configure markdown with extensions
+md = markdown.Markdown(
+    extensions=[
+        'markdown.extensions.codehilite',
+        'markdown.extensions.tables',
+        'markdown.extensions.fenced_code',
+        'markdown.extensions.sane_lists'
+    ],
+    extension_configs={
+        'markdown.extensions.codehilite': {
+            'css_class': 'highlight',
+            'use_pygments': True
+        }
+    }
+)
+
+# Convert markdown to HTML
+html_content = md.convert(readme_content)
+
+# Get syntax highlighting CSS
+formatter = HtmlFormatter(style='default')
+pygments_css = formatter.get_style_defs('.highlight')
+
+# Create complete HTML document
+full_html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>README</title>
+    <style>
+{pygments_css}
+body {{
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 40px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    line-height: 1.6;
+}}
+table {{
+    border-collapse: collapse;
+    width: 100%;
+    margin: 20px 0;
+}}
+th, td {{
+    border: 1px solid #ddd;
+    padding: 12px;
+    text-align: left;
+}}
+th {{
+    background-color: #f5f5f5;
+    font-weight: bold;
+}}
+    </style>
+</head>
+<body>
+{html_content}
+</body>
+</html>"""
+
+# Write to index.html
+with open('index.html', 'w', encoding='utf-8') as f:
+    f.write(full_html)
+
+print("✅ README.md converted to index.html")

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ def get_access_token():
         raise Exception(f"Error: {response.status_code} - {response.text}")
 ```
 
-### C#
+### C-Sharp
 
 ```csharp
 using System;


### PR DESCRIPTION
I have added the GitHub Pages pipeline. The URL will be https://eco-platform.github.io/ECO_Portal_M2M_Authentication_Guide (I think). 

However, you need to create a token at https://github.com/settings/tokens in the upper right corner by selecting `Generate new token (classic)`. For me, it works when I only enable `repoFull`.

Then, on this repository, go to [`Settings -> Secrets -> Actions -> New secret`](https://github.com/ECO-Platform/ECO_Portal_M2M_Authentication_Guide/settings/secrets/actions/new).

The secret name must be `GH_PAGES_DEPLOY`, and then paste your token under secrets.